### PR TITLE
Use conventions for .env and private-key.pem

### DIFF
--- a/.env
+++ b/.env
@@ -1,3 +1,0 @@
-# The ID of your GitHub integration
-INTEGRATION_ID=1860
-PRIVATE_KEY=key.pem

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 node_modules
 npm-debug.log
-key.pem
 prod.pem
 .env
+private-key.pem

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules
 npm-debug.log
 key.pem
 prod.pem
+.env

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "repository": "MarshallOfSound/probot-issue-duplicate-detection",
   "scripts": {
     "deploy": "now --alias=duplicate.probot.samuelattard.us",
-    "start": "probot run ./index.js --private-key=key.pem",
+    "start": "probot run ./index.js",
     "now-start": "probot run ./index.js --private-key=prod.pem --integration=1862",
     "test": "xo --extend probot"
   },


### PR DESCRIPTION
- `probot run` looks for `private-key.pem` by default in development, so there's no need to specify it on the command line. This is documented in https://github.com/probot/probot/blob/master/docs/development.md, but would love feedback on spelling this out more clearly
- `.env` should not be committed since that will be different for each person