### PR TITLE
Use `.github/DUPLICATE_ISSUE_TEMPLATE.md` if it exists

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,32 @@ npm run
 
 For more information, see the [documentation for probot](https://github.com/probot/probot).
 
+## Configuring
+
+The bot will comment with the template below by default. You can change it by creating a file in `.github/DUPLICATE_ISSUE_TEMPLATE.md` and customizing the contents.
+
+The template uses [mustache](https://mustache.github.io/) for rendering, and has two variables available:
+
+- `payload`: The payload from the [issue webhook event](https://developer.github.com/v3/activity/events/types/#issuesevent).
+- `issues`: An array of duplicate [issues](https://developer.github.com/v3/issues/#list-issues-for-a-repository)
+
+```md
+Hey @{{ payload.sender.login }},
+
+We did a quick check and this issue looks very darn similar to
+
+{{#issues}}
+* [#{{ number }} - {{ title }}]({{ number }})
+{{/issues}}
+
+This could be a coincidence, but if any of these issues solves your problem then I did a good job :smile:
+
+If not, the maintainers will get to this issue shortly.
+
+Cheers,
+Your Friendly Neighborhood ProBot
+```
+
 ## Deploying to Now
 
 1. Install the now CLI with `npm i -g now`

--- a/index.js
+++ b/index.js
@@ -1,4 +1,8 @@
+const fs = require('fs');
 const Fuze = require('fuse.js');
+const mustache = require('mustache');
+
+const template = fs.readFileSync('./template.md', {encoding: 'utf-8'});
 
 module.exports = robot => {
   robot.on('issues.opened', async (event, context) => {
@@ -23,19 +27,10 @@ module.exports = robot => {
 
     const results = fuse.search(theIssue.title);
     if (results.length > 0) {
-      const commentBody =
-`Hey There,
-We did a quick check and this issue looks very darn similar to
-${results.slice(0, 3).map(
-  issue => `* [#${issue.number} - ${issue.title}](${issue.number})`
-).join('  \n')}
-
-This could be a cooincidence, but if any of these issues solves your problem then I did a good job :smile:
-
-If not, the maintainers will get to this issue shortly.
-
-Cheers,
-Your Friendly Neighborhood ProBot`;
+      const commentBody = mustache.render(template, {
+        payload: event.payload,
+        issues: otherIssues.slice(0, 3)
+      });
 
       await github.issues.createComment(context.issue({body: commentBody}));
     }

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   },
   "dependencies": {
     "fuse.js": "^2.6.2",
+    "mustache": "^2.3.0",
     "probot": "~0.2.0"
   },
   "devDependencies": {

--- a/template.md
+++ b/template.md
@@ -1,0 +1,14 @@
+Hey @{{ payload.sender.login }},
+
+We did a quick check and this issue looks very darn similar to
+
+{{#issues}}
+* [#{{ number }} - {{ title }}]({{ number }})
+{{/issues}}
+
+This could be a coincidence, but if any of these issues solves your problem then I did a good job :smile:
+
+If not, the maintainers will get to this issue shortly.
+
+Cheers,
+Your Friendly Neighborhood ProBot


### PR DESCRIPTION
This updates the bot to use the contents of `.github/DUPLICATE_ISSUE_TEMPLATE.md` if it exists. Here are the docs added to the readme:

## Configuring

The bot will comment with the template below by default. You can change it by creating a file in `.github/DUPLICATE_ISSUE_TEMPLATE.md` and customizing the contents.

The template uses [mustache](https://mustache.github.io/) for rendering, and has two variables available:

- `payload`: The payload from the [issue webhook event](https://developer.github.com/v3/activity/events/types/#issuesevent).
- `issues`: An array of duplicate [issues](https://developer.github.com/v3/issues/#list-issues-for-a-repository)

```
Hey @{{ payload.sender.login }},

We did a quick check and this issue looks very darn similar to

{{#issues}}
* [#{{ number }} - {{ title }}]({{ number }})
{{/issues}}

This could be a coincidence, but if any of these issues solves your problem then I did a good job :smile:

If not, the maintainers will get to this issue shortly.

Cheers,
Your Friendly Neighborhood ProBot
```

cc @lee-dohm